### PR TITLE
Add Apache license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2013 Puppet, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
I updated `jira-backup` and added the capability to back up Atlassian Confluence as well.  I want to contribute my changes, but I first need a license to do so.  I see that you usually use the Apache license.

Just to make this super quick and easy for you, I have created license file `LICENSE` for you so all you need to do is merge this PR.