### PR TITLE
Two Enhancements : Deleting Old Backups and Optional DBDumps

### DIFF
--- a/configs/jira-backup.conf
+++ b/configs/jira-backup.conf
@@ -8,3 +8,6 @@ DB_NAME='jira'
 DB_HOST=
 DB_USER='jira'
 DB_PASS=
+
+# History
+KEEP_DAYS=30

--- a/files/jira-backup
+++ b/files/jira-backup
@@ -11,7 +11,9 @@ else
 fi
 
 ATTACHMENT_BACKUP_OUTPUT="${BACKUP_DIR}/jira-attachments-${TIMESTAMP}.tar"
+ATTACHMENT_BACKUP_REMOVE="${BACKUP_DIR}/jira-attachments-*.tar"
 DATABASE_DUMP_OUTPUT="${BACKUP_DIR}/jira-database-dump-${TIMESTAMP}.sql"
+DATABASE_DUMP_REMOVE="${BACKUP_DIR}/jira-database-dump-*.sql"
 
 
 function setup() {
@@ -21,21 +23,48 @@ function setup() {
     fi
 }
 
+function remove_old_files() {
+    if [ -n "${KEEP_DAYS}" ] then
+        find $0 -mtime +${KEEP_DAYS} -exec rm {} \;
+    fi
+}
+
+function remove_old_attachment_backups() {
+    echo "Removing old Jira attachment backups"	
+    remove_old_files ${ATTACHMENT_BACKUP_REMOVE}
+}
+
+function remove_old_database_dumps() {
+    echo "Removing old Jira database dumps"
+    remove_old_files {$DATABASE_DUMP_REMOVE}
+}
+
+
 function backup_attachments() {
-    echo "Backing up Jira attachments"
-    /bin/tar -cpf ${ATTACHMENT_BACKUP_OUTPUT} ${ATTACHMENTS_PATH}
-    echo "Created ${ATTACHMENT_BACKUP_OUTPUT}"
+    if [ -z "${ATTACHMENTS_PATH}" ] then
+        echo "Skipping Jira attachments backup"
+    else
+	 echo "Backing up Jira attachments"
+         /bin/tar -cpf ${ATTACHMENT_BACKUP_OUTPUT} ${ATTACHMENTS_PATH}
+         echo "Created ${ATTACHMENT_BACKUP_OUTPUT}"
+    fi
 }
 
 function dump_database() {
-    echo "Dumping Jira database"
-    /usr/bin/pg_dump -U "${DB_USER}" "${DB_NAME}" -h "${DB_HOST}" > "${DATABASE_DUMP_OUTPUT}"
-    echo "Created ${DATABASE_DUMP_OUTPUT}"
+    if [ -z "$DB_NAME" ] then
+        echo "Skiping Jira database dump."
+    else
+        echo "Dumping Jira database"
+        /usr/bin/pg_dump -U "${DB_USER}" "${DB_NAME}" -h "${DB_HOST}" > "${DATABASE_DUMP_OUTPUT}"
+        echo "Created ${DATABASE_DUMP_OUTPUT}"
+    fi
 }
 
 function main() {
     echo "Backing up Jira"
     setup
+    remove_old_attachment_backups
+    remove_old_database_dumps
     backup_attachments
     dump_database
 }


### PR DESCRIPTION
1. Based on KEEP_DAYS configuration, old backups and dumps are deleted. 
1. If postgres database is remote, it is meaningless take pg_dumps. Accordingly if DB_NAME is empty, pg_dump is skipped. If ATTACHMENTS_PATH is empty, jira data backup is skipped so we can execute pg_dumps via script on remote database server.