### PR TITLE
Deleting Old Backup Files and Optional Attachments and DB Backups

### DIFF
--- a/configs/jira-backup.conf
+++ b/configs/jira-backup.conf
@@ -8,3 +8,6 @@ DB_NAME='jira'
 DB_HOST=
 DB_USER='jira'
 DB_PASS=
+
+# History
+KEEP_DAYS=30

--- a/configs/jira-backup.conf
+++ b/configs/jira-backup.conf
@@ -1,7 +1,7 @@
 BACKUP_DIR='/var/atlassian/backups/jira'
 
 # Attachments
-ATTACHMENTS_PATH='/var/atlassian/application-data/jira/data/attachments'
+ATTACHMENTS_PATH='var/atlassian/application-data/jira/data/attachments'
 
 # Database
 DB_NAME='jira'

--- a/files/jira-backup
+++ b/files/jira-backup
@@ -24,34 +24,38 @@ function setup() {
 }
 
 function remove_old_files() {
-    if [ -n "${KEEP_DAYS}" ] then
-        find $0 -mtime +${KEEP_DAYS} -exec rm {} \;
+    if [ -n "${KEEP_DAYS}" ]; then
+        find "$1" -mtime +${KEEP_DAYS} -delete
     fi
 }
 
 function remove_old_attachment_backups() {
-    echo "Removing old Jira attachment backups"	
-    remove_old_files ${ATTACHMENT_BACKUP_REMOVE}
+    if [ -z "${ATTACHMENTS_PATH}" ]; then
+        echo "Removing old Jira attachment backups"
+        remove_old_files "$ATTACHMENT_BACKUP_REMOVE"
+    fi
 }
 
 function remove_old_database_dumps() {
-    echo "Removing old Jira database dumps"
-    remove_old_files {$DATABASE_DUMP_REMOVE}
+    if [ -z "$DB_NAME" ]; then
+        echo "Removing old Jira database dumps"
+        remove_old_files "$DATABASE_DUMP_REMOVE"
+    fi
 }
 
 
 function backup_attachments() {
-    if [ -z "${ATTACHMENTS_PATH}" ] then
+    if [ -z "${ATTACHMENTS_PATH}" ]; then
         echo "Skipping Jira attachments backup"
     else
-	 echo "Backing up Jira attachments"
-         /bin/tar -cpf ${ATTACHMENT_BACKUP_OUTPUT} ${ATTACHMENTS_PATH}
-         echo "Created ${ATTACHMENT_BACKUP_OUTPUT}"
+	    echo "Backing up Jira attachments"
+        /bin/tar -cpf ${ATTACHMENT_BACKUP_OUTPUT} ${ATTACHMENTS_PATH}
+        echo "Created ${ATTACHMENT_BACKUP_OUTPUT}"
     fi
 }
 
 function dump_database() {
-    if [ -z "$DB_NAME" ] then
+    if [ -z "$DB_NAME" ]; then
         echo "Skiping Jira database dump."
     else
         echo "Dumping Jira database"

--- a/files/jira-backup
+++ b/files/jira-backup
@@ -11,7 +11,9 @@ else
 fi
 
 ATTACHMENT_BACKUP_OUTPUT="${BACKUP_DIR}/jira-attachments-${TIMESTAMP}.tar"
+ATTACHMENT_BACKUP_REMOVE="${BACKUP_DIR}/jira-attachments-*.tar"
 DATABASE_DUMP_OUTPUT="${BACKUP_DIR}/jira-database-dump-${TIMESTAMP}.sql"
+DATABASE_DUMP_REMOVE="${BACKUP_DIR}/jira-database-dump-*.sql"
 
 
 function setup() {
@@ -21,21 +23,48 @@ function setup() {
     fi
 }
 
+function remove_old_files() {
+    if [ -n "${KEEP_DAYS}" ] then
+        find $0 -mtime +${KEEP_DAYS} -exec rm {} \;
+    fi
+}
+
+function remove_old_attachment_backups() {
+    echo "Removing old Jira attachment backups"	
+    remove_old_files ${ATTACHMENT_BACKUP_REMOVE}
+}
+
+function remove_old_database_dumps() {
+    echo "Removing old Jira database dumps"
+    remove_old_files {$DATABASE_DUMP_REMOVE}
+}
+
+
 function backup_attachments() {
-    echo "Backing up Jira attachments"
-    /bin/tar -cpf ${ATTACHMENT_BACKUP_OUTPUT} ${ATTACHMENTS_PATH}
-    echo "Created ${ATTACHMENT_BACKUP_OUTPUT}"
+    if [ -z "${ATTACHMENTS_PATH}" ] then
+        echo "Skipping Jira attachments backup"
+    else
+	 echo "Backing up Jira attachments"
+         /bin/tar -cpf ${ATTACHMENT_BACKUP_OUTPUT} ${ATTACHMENTS_PATH}
+         echo "Created ${ATTACHMENT_BACKUP_OUTPUT}"
+    fi
 }
 
 function dump_database() {
-    echo "Dumping Jira database"
-    /usr/bin/pg_dump -U "${DB_USER}" "${DB_NAME}" -h "${DB_HOST}" > "${DATABASE_DUMP_OUTPUT}"
-    echo "Created ${DATABASE_DUMP_OUTPUT}"
+    if [ -z "$DB_NAME" ] then
+        echo "Skiping Jira database dump."
+    else
+        echo "Dumping Jira database"
+        /usr/bin/pg_dump -U "${DB_USER}" "${DB_NAME}" -h "${DB_HOST}" > "${DATABASE_DUMP_OUTPUT}"
+        echo "Created ${DATABASE_DUMP_OUTPUT}"
+    fi
 }
 
 function main() {
     echo "Backing up Jira"
     setup
+    remove_old_attachment_backups
+    remove_old_database_dumps
     backup_attachments
     dump_database
 }

--- a/files/jira-backup
+++ b/files/jira-backup
@@ -25,19 +25,19 @@ function setup() {
 
 function remove_old_files() {
     if [ -n "${KEEP_DAYS}" ]; then
-        find "$1" -mtime +${KEEP_DAYS} -delete
+        find $1 -mtime +${KEEP_DAYS} -delete -print
     fi
 }
 
 function remove_old_attachment_backups() {
-    if [ -z "${ATTACHMENTS_PATH}" ]; then
+    if [ -n "${ATTACHMENTS_PATH}" ]; then
         echo "Removing old Jira attachment backups"
         remove_old_files "$ATTACHMENT_BACKUP_REMOVE"
     fi
 }
 
 function remove_old_database_dumps() {
-    if [ -z "$DB_NAME" ]; then
+    if [ -n "$DB_NAME" ]; then
         echo "Removing old Jira database dumps"
         remove_old_files "$DATABASE_DUMP_REMOVE"
     fi
@@ -49,7 +49,10 @@ function backup_attachments() {
         echo "Skipping Jira attachments backup"
     else
 	    echo "Backing up Jira attachments"
-        /bin/tar -cpf ${ATTACHMENT_BACKUP_OUTPUT} ${ATTACHMENTS_PATH}
+        # In order suppress "/bin/tar: Removing leading `/' from member names" warning
+        # -C / parameter added and leading / removed from ATTACHMENTS_PATH
+        # See details : https://unix.stackexchange.com/a/61760
+        /bin/tar -cpf ${ATTACHMENT_BACKUP_OUTPUT} -C / ${ATTACHMENTS_PATH}
         echo "Created ${ATTACHMENT_BACKUP_OUTPUT}"
     fi
 }

--- a/files/jira-backup
+++ b/files/jira-backup
@@ -62,7 +62,9 @@ function dump_database() {
         echo "Skiping Jira database dump."
     else
         echo "Dumping Jira database"
-        /usr/bin/pg_dump -U "${DB_USER}" "${DB_NAME}" -h "${DB_HOST}" > "${DATABASE_DUMP_OUTPUT}"
+        # Don't pass hostname and username since we'll run this postgres user in local machine
+        # /usr/bin/pg_dump -U "${DB_USER}" "${DB_NAME}" -h "${DB_HOST}" > "${DATABASE_DUMP_OUTPUT}"
+        /usr/bin/pg_dump  "${DB_NAME}"  > "${DATABASE_DUMP_OUTPUT}"
         echo "Created ${DATABASE_DUMP_OUTPUT}"
     fi
 }


### PR DESCRIPTION
1. Based on KEEP_DAYS configuration, old backups and dumps are deleted.
1. If postgres database is remote, it is meaningless take pg_dumps. Accordingly if DB_NAME is empty, pg_dump is skipped. If ATTACHMENTS_PATH is empty, jira data backup is skipped so we can execute pg_dumps via script on remote database server.
1. In order suppress "/bin/tar: Removing leading `/' from member names" warning -C / parameter added and leading / removed from ATTACHMENTS_PATH See details : https://unix.stackexchange.com/a/61760
1. Dropped DB_HOST and DB_USER parameters from pg_dump. I assumed that backup will be executed by postgres user. Otherwise, in order to pass password, it is needed to create .pgpass file in user home directory.